### PR TITLE
Expose parameters in create_event_on_device()

### DIFF
--- a/zenoss.py
+++ b/zenoss.py
@@ -504,7 +504,7 @@ class Zenoss(object):
         '''
         return self.change_event_state(event_id, 'close')
 
-    def create_event_on_device(self, device_name, severity, summary):
+    def create_event_on_device(self, device_name, severity, summary, component='', evclasskey='', evclass=''):
         '''Manually create a new event for the device specified.
 
         '''
@@ -522,9 +522,9 @@ class Zenoss(object):
         data = dict(device=device_name,
                     summary=summary,
                     severity=severity,
-                    component='',
-                    evclasskey='',
-                    evclass='')
+                    component=component,
+                    evclasskey=evclasskey,
+                    evclass=evclass)
         return self.__router_request('EventsRouter', 'add_event', [data])
 
     def get_load_average(self, device):


### PR DESCRIPTION
Add keyword parameters for 'component', 'evclass' and 'evclasskey'
event parameters.